### PR TITLE
Update dotnet version parametrize the collection type

### DIFF
--- a/FindDuplicates/Benchmark.cs
+++ b/FindDuplicates/Benchmark.cs
@@ -6,8 +6,7 @@ namespace FindDuplicates;
 [ReturnValueValidator(failOnError: true)]
 public class Benchmark
 {
-    private IEnumerable<int> _enumerable;
-    private ICollection<int> _collection;
+    private IEnumerable<int> _collection = null!;
 
     [Params(100, 1_000, 10_000)]
     public int Size { get; set; }
@@ -15,92 +14,49 @@ public class Benchmark
     [Params(Location.None, Location.Beginning, Location.FortyOnePercent, Location.End)]
     public Location DuplicateLocation { get; set; }
 
+    [Params(CollectionType.Array, CollectionType.Enumerable)]
+    public CollectionType CollectionType { get; set; }
 
     [GlobalSetup]
     public void GlobalSetup()
     {
-        var duplicateIndex = GetDuplicateIndex();
-
-        _enumerable = duplicateIndex.HasValue
-            ? Enumerable
-                .Range(1, Size)
-                .Select((value, index) => index == duplicateIndex.Value ? index : value)
-            : Enumerable
-                .Range(1, Size);
-
-        _collection = _enumerable.ToArray();
+        _collection = GetCollection();
     }
 
     [Benchmark(Baseline = true)]
-    public bool ForeachCollection()
+    public bool Foreach()
     {
         return ContainsDuplicates.ForEach(_collection);
     }
 
     [Benchmark]
-    public bool LinqAnyCollection()
+    public bool LinqAny()
     {
         return ContainsDuplicates.LinqAny(_collection);
     }
 
     [Benchmark]
-    public bool LinqAllCollection()
+    public bool LinqAll()
     {
         return ContainsDuplicates.LinqAll(_collection);
     }
 
     [Benchmark]
-    public bool LinqDistinctCollection()
+    public bool LinqDistinct()
     {
         return ContainsDuplicates.LinqDistinct(_collection);
     }
 
     [Benchmark]
-    public bool LinqGroupByCollection()
+    public bool LinqGroupBy()
     {
         return ContainsDuplicates.LinqGroupBy(_collection);
     }
 
     [Benchmark]
-    public bool ToHashSetCollection()
+    public bool ToHashSet()
     {
         return ContainsDuplicates.ToHashSet(_collection);
-    }
-
-    [Benchmark]
-    public bool ForeachEnumerable()
-    {
-        return ContainsDuplicates.ForEach(_enumerable);
-    }
-
-    [Benchmark]
-    public bool LinqAnyEnumerable()
-    {
-        return ContainsDuplicates.LinqAny(_enumerable);
-    }
-
-    [Benchmark]
-    public bool LinqAllEnumerable()
-    {
-        return ContainsDuplicates.LinqAll(_enumerable);
-    }
-
-    [Benchmark]
-    public bool LinqDistinctEnumerable()
-    {
-        return ContainsDuplicates.LinqDistinct(_enumerable);
-    }
-
-    [Benchmark]
-    public bool LinqGroupByEnumerable()
-    {
-        return ContainsDuplicates.LinqGroupBy(_enumerable);
-    }
-
-    [Benchmark]
-    public bool ToHashSetEnumerable()
-    {
-        return ContainsDuplicates.ToHashSet(_enumerable);
     }
 
     private int? GetDuplicateIndex() => DuplicateLocation switch
@@ -111,4 +67,24 @@ public class Benchmark
         Location.End => Size - 1,
         _ => throw new NotSupportedException("Location is not supported")
     };
+
+    private IEnumerable<int> GetCollection()
+    {
+        var duplicateIndex = GetDuplicateIndex();
+
+        var items = duplicateIndex.HasValue
+            ? Enumerable
+                .Range(1, Size)
+                .Select((value, index) => index == duplicateIndex.Value ? index : value)
+            : Enumerable
+                .Range(1, Size);
+
+
+        return CollectionType switch
+        {
+            CollectionType.Array => items.ToArray(),
+            CollectionType.Enumerable => items,
+            _ => throw new NotSupportedException("CollectionType is not supported")
+        };
+    }
 }

--- a/FindDuplicates/CollectionType.cs
+++ b/FindDuplicates/CollectionType.cs
@@ -1,0 +1,7 @@
+﻿namespace FindDuplicates;
+
+public enum CollectionType  
+{
+    Array,
+    Enumerable
+}

--- a/FindDuplicates/FindDuplicates.csproj
+++ b/FindDuplicates/FindDuplicates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -3,170 +3,184 @@
 Benchmark showcasing 6 ways to check if a collection contains a duplicate element
 
 ``` ini
-BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.1413)
-11th Gen Intel Core i9-11950H 2.60GHz, 1 CPU, 16 logical and 8 physical cores
-.NET SDK=7.0.202
-  [Host]     : .NET 6.0.15 (6.0.1523.11507), X64 RyuJIT AVX2
-  DefaultJob : .NET 6.0.15 (6.0.1523.11507), X64 RyuJIT AVX2
-```
 
-| Method                 | Size      | DuplicateLocation   |             Mean |            Error |           StdDev |     Ratio |  RatioSD |    Allocated | Alloc Ratio |
-| ---------------------- | --------- | ------------------- | ---------------: | ---------------: | ---------------: | --------: | -------: | -----------: | ----------: |
-| **ForeachCollection**  | **100**   | **None**            |    **728.76 ns** |     **5.546 ns** |     **5.187 ns** |  **1.00** | **0.00** |   **1864 B** |    **1.00** |
-| LinqAnyCollection      | 100       | None                |        805.60 ns |         9.332 ns |         8.729 ns |      1.11 |     0.01 |       1952 B |        1.05 |
-| LinqAllCollection      | 100       | None                |        760.15 ns |         6.393 ns |         5.980 ns |      1.04 |     0.01 |       1928 B |        1.03 |
-| LinqDistinctCollection | 100       | None                |        711.19 ns |         9.877 ns |         9.239 ns |      0.98 |     0.02 |       1928 B |        1.03 |
-| LinqGroupByCollection  | 100       | None                |      3,461.56 ns |        32.235 ns |        28.576 ns |      4.75 |     0.05 |      11032 B |        5.92 |
-| ToHashSetCollection    | 100       | None                |        691.46 ns |         5.850 ns |         5.186 ns |      0.95 |     0.01 |       1864 B |        1.00 |
-| ForeachEnumerable      | 100       | None                |      1,614.66 ns |        22.186 ns |        20.753 ns |      2.22 |     0.03 |       6112 B |        3.28 |
-| LinqAnyEnumerable      | 100       | None                |      1,717.49 ns |        15.986 ns |        14.953 ns |      2.36 |     0.02 |       6200 B |        3.33 |
-| LinqAllEnumerable      | 100       | None                |      1,674.47 ns |        20.232 ns |        18.925 ns |      2.30 |     0.03 |       6176 B |        3.31 |
-| LinqDistinctEnumerable | 100       | None                |      2,212.13 ns |        25.981 ns |        24.303 ns |      3.04 |     0.04 |       6288 B |        3.37 |
-| LinqGroupByEnumerable  | 100       | None                |      3,784.87 ns |        38.417 ns |        34.056 ns |      5.19 |     0.06 |      11112 B |        5.96 |
-| ToHashSetEnumerable    | 100       | None                |      2,201.34 ns |        25.654 ns |        23.997 ns |      3.02 |     0.05 |       6224 B |        3.34 |
-|                        |           |                     |                  |                  |                  |           |          |              |             |
-| **ForeachCollection**  | **100**   | **Beginning**       |     **91.67 ns** |     **1.736 ns** |     **1.624 ns** |  **1.00** | **0.00** |   **1864 B** |    **1.00** |
-| LinqAnyCollection      | 100       | Beginning           |        101.88 ns |         1.467 ns |         1.372 ns |      1.11 |     0.02 |       1952 B |        1.05 |
-| LinqAllCollection      | 100       | Beginning           |        100.56 ns |         1.968 ns |         1.744 ns |      1.10 |     0.03 |       1928 B |        1.03 |
-| LinqDistinctCollection | 100       | Beginning           |        720.45 ns |        13.422 ns |        12.555 ns |      7.86 |     0.18 |       1928 B |        1.03 |
-| LinqGroupByCollection  | 100       | Beginning           |      2,653.83 ns |        20.327 ns |        16.974 ns |     29.00 |     0.61 |      10976 B |        5.89 |
-| ToHashSetCollection    | 100       | Beginning           |        696.03 ns |        11.184 ns |        10.461 ns |      7.60 |     0.19 |       1864 B |        1.00 |
-| ForeachEnumerable      | 100       | Beginning           |         60.25 ns |         0.456 ns |         0.405 ns |      0.66 |     0.01 |        280 B |        0.15 |
-| LinqAnyEnumerable      | 100       | Beginning           |         70.09 ns |         1.010 ns |         0.945 ns |      0.76 |     0.02 |        368 B |        0.20 |
-| LinqAllEnumerable      | 100       | Beginning           |         70.13 ns |         1.401 ns |         1.311 ns |      0.77 |     0.02 |        344 B |        0.18 |
-| LinqDistinctEnumerable | 100       | Beginning           |      2,214.45 ns |        22.375 ns |        19.835 ns |     24.15 |     0.48 |       6288 B |        3.37 |
-| LinqGroupByEnumerable  | 100       | Beginning           |      2,953.69 ns |        38.794 ns |        36.288 ns |     32.23 |     0.77 |      11056 B |        5.93 |
-| ToHashSetEnumerable    | 100       | Beginning           |      2,283.39 ns |        35.413 ns |        33.126 ns |     24.92 |     0.56 |       6224 B |        3.34 |
-|                        |           |                     |                  |                  |                  |           |          |              |             |
-| **ForeachCollection**  | **100**   | **FortyOnePercent** |    **356.43 ns** |     **3.574 ns** |     **3.343 ns** |  **1.00** | **0.00** |   **1864 B** |    **1.00** |
-| LinqAnyCollection      | 100       | FortyOnePercent     |        401.00 ns |         4.130 ns |         3.863 ns |      1.13 |     0.01 |       1952 B |        1.05 |
-| LinqAllCollection      | 100       | FortyOnePercent     |        383.62 ns |         7.008 ns |         6.556 ns |      1.08 |     0.02 |       1928 B |        1.03 |
-| LinqDistinctCollection | 100       | FortyOnePercent     |        716.35 ns |         9.690 ns |         8.092 ns |      2.01 |     0.02 |       1928 B |        1.03 |
-| LinqGroupByCollection  | 100       | FortyOnePercent     |      2,854.94 ns |        27.816 ns |        26.019 ns |      8.01 |     0.09 |      10976 B |        5.89 |
-| ToHashSetCollection    | 100       | FortyOnePercent     |        710.88 ns |         5.957 ns |         5.572 ns |      1.99 |     0.03 |       1864 B |        1.00 |
-| ForeachEnumerable      | 100       | FortyOnePercent     |        743.03 ns |        14.049 ns |        13.142 ns |      2.08 |     0.03 |       2904 B |        1.56 |
-| LinqAnyEnumerable      | 100       | FortyOnePercent     |        792.53 ns |         9.787 ns |         9.155 ns |      2.22 |     0.02 |       2992 B |        1.61 |
-| LinqAllEnumerable      | 100       | FortyOnePercent     |        799.57 ns |         7.663 ns |         6.793 ns |      2.24 |     0.03 |       2968 B |        1.59 |
-| LinqDistinctEnumerable | 100       | FortyOnePercent     |      2,288.78 ns |        21.175 ns |        19.807 ns |      6.42 |     0.08 |       6288 B |        3.37 |
-| LinqGroupByEnumerable  | 100       | FortyOnePercent     |      3,398.62 ns |        43.017 ns |        40.238 ns |      9.54 |     0.14 |      11056 B |        5.93 |
-| ToHashSetEnumerable    | 100       | FortyOnePercent     |      2,236.50 ns |        36.876 ns |        34.494 ns |      6.28 |     0.12 |       6224 B |        3.34 |
-|                        |           |                     |                  |                  |                  |           |          |              |             |
-| **ForeachCollection**  | **100**   | **End**             |    **718.52 ns** |     **7.584 ns** |     **7.094 ns** |  **1.00** | **0.00** |   **1864 B** |    **1.00** |
-| LinqAnyCollection      | 100       | End                 |        803.10 ns |        13.940 ns |        13.040 ns |      1.12 |     0.02 |       1952 B |        1.05 |
-| LinqAllCollection      | 100       | End                 |        757.83 ns |         3.566 ns |         3.161 ns |      1.06 |     0.01 |       1928 B |        1.03 |
-| LinqDistinctCollection | 100       | End                 |        704.21 ns |         7.443 ns |         6.962 ns |      0.98 |     0.01 |       1928 B |        1.03 |
-| LinqGroupByCollection  | 100       | End                 |      3,380.05 ns |        55.403 ns |        51.824 ns |      4.70 |     0.08 |      10976 B |        5.89 |
-| ToHashSetCollection    | 100       | End                 |        696.49 ns |         8.856 ns |         8.284 ns |      0.97 |     0.01 |       1864 B |        1.00 |
-| ForeachEnumerable      | 100       | End                 |      1,610.49 ns |        10.704 ns |         9.489 ns |      2.24 |     0.03 |       6112 B |        3.28 |
-| LinqAnyEnumerable      | 100       | End                 |      1,709.64 ns |        24.197 ns |        22.634 ns |      2.38 |     0.03 |       6200 B |        3.33 |
-| LinqAllEnumerable      | 100       | End                 |      1,692.55 ns |        30.752 ns |        28.765 ns |      2.36 |     0.05 |       6176 B |        3.31 |
-| LinqDistinctEnumerable | 100       | End                 |      2,263.48 ns |        19.933 ns |        18.645 ns |      3.15 |     0.04 |       6288 B |        3.37 |
-| LinqGroupByEnumerable  | 100       | End                 |      3,763.57 ns |        49.616 ns |        46.411 ns |      5.24 |     0.09 |      11056 B |        5.93 |
-| ToHashSetEnumerable    | 100       | End                 |      2,257.88 ns |        21.405 ns |        18.975 ns |      3.15 |     0.04 |       6224 B |        3.34 |
-|                        |           |                     |                  |                  |                  |           |          |              |             |
-| **ForeachCollection**  | **1000**  | **None**            |  **6,721.72 ns** |    **70.320 ns** |    **65.778 ns** |  **1.00** | **0.00** |  **17800 B** |    **1.00** |
-| LinqAnyCollection      | 1000      | None                |      7,605.59 ns |       115.055 ns |       107.622 ns |      1.13 |     0.02 |      17888 B |        1.00 |
-| LinqAllCollection      | 1000      | None                |      6,992.34 ns |        55.749 ns |        52.148 ns |      1.04 |     0.01 |      17864 B |        1.00 |
-| LinqDistinctCollection | 1000      | None                |      6,467.82 ns |        67.464 ns |        63.106 ns |      0.96 |     0.01 |      17864 B |        1.00 |
-| LinqGroupByCollection  | 1000      | None                |     32,918.73 ns |       527.540 ns |       586.359 ns |      4.89 |     0.11 |     104616 B |        5.88 |
-| ToHashSetCollection    | 1000      | None                |      6,459.93 ns |        51.246 ns |        45.429 ns |      0.96 |     0.01 |      17800 B |        1.00 |
-| ForeachEnumerable      | 1000      | None                |     14,765.92 ns |       109.026 ns |        96.649 ns |      2.20 |     0.03 |      58776 B |        3.30 |
-| LinqAnyEnumerable      | 1000      | None                |     15,608.31 ns |       150.437 ns |       133.359 ns |      2.32 |     0.03 |      58864 B |        3.31 |
-| LinqAllEnumerable      | 1000      | None                |     15,877.61 ns |       145.314 ns |       128.817 ns |      2.36 |     0.04 |      58840 B |        3.31 |
-| LinqDistinctEnumerable | 1000      | None                |     20,627.36 ns |       337.672 ns |       315.859 ns |      3.07 |     0.06 |      58952 B |        3.31 |
-| LinqGroupByEnumerable  | 1000      | None                |     36,276.42 ns |       383.624 ns |       358.842 ns |      5.40 |     0.07 |     104696 B |        5.88 |
-| ToHashSetEnumerable    | 1000      | None                |     20,473.26 ns |       202.226 ns |       189.163 ns |      3.05 |     0.04 |      58888 B |        3.31 |
-|                        |           |                     |                  |                  |                  |           |          |              |             |
-| **ForeachCollection**  | **1000**  | **Beginning**       |    **599.03 ns** |    **11.105 ns** |     **9.274 ns** |  **1.00** | **0.00** |  **17800 B** |    **1.00** |
-| LinqAnyCollection      | 1000      | Beginning           |        596.36 ns |        11.755 ns |        12.577 ns |      0.99 |     0.03 |      17888 B |        1.00 |
-| LinqAllCollection      | 1000      | Beginning           |        593.93 ns |        11.585 ns |        13.342 ns |      0.99 |     0.03 |      17864 B |        1.00 |
-| LinqDistinctCollection | 1000      | Beginning           |      6,442.46 ns |        73.585 ns |        68.831 ns |     10.78 |     0.21 |      17864 B |        1.00 |
-| LinqGroupByCollection  | 1000      | Beginning           |     23,099.24 ns |       303.098 ns |       283.518 ns |     38.59 |     0.66 |     104560 B |        5.87 |
-| ToHashSetCollection    | 1000      | Beginning           |      6,455.51 ns |        65.933 ns |        61.674 ns |     10.80 |     0.17 |      17800 B |        1.00 |
-| ForeachEnumerable      | 1000      | Beginning           |         59.59 ns |         0.762 ns |         0.713 ns |      0.10 |     0.00 |        280 B |        0.02 |
-| LinqAnyEnumerable      | 1000      | Beginning           |         70.32 ns |         0.886 ns |         0.828 ns |      0.12 |     0.00 |        368 B |        0.02 |
-| LinqAllEnumerable      | 1000      | Beginning           |         67.81 ns |         1.074 ns |         1.005 ns |      0.11 |     0.00 |        344 B |        0.02 |
-| LinqDistinctEnumerable | 1000      | Beginning           |     20,953.85 ns |       410.931 ns |       384.385 ns |     35.07 |     0.93 |      58952 B |        3.31 |
-| LinqGroupByEnumerable  | 1000      | Beginning           |     28,470.08 ns |       428.789 ns |       401.090 ns |     47.63 |     1.00 |     104640 B |        5.88 |
-| ToHashSetEnumerable    | 1000      | Beginning           |     20,251.63 ns |       366.614 ns |       342.931 ns |     33.71 |     0.71 |      58888 B |        3.31 |
-|                        |           |                     |                  |                  |                  |           |          |              |             |
-| **ForeachCollection**  | **1000**  | **FortyOnePercent** |  **3,096.57 ns** |    **40.166 ns** |    **37.571 ns** |  **1.00** | **0.00** |  **17800 B** |    **1.00** |
-| LinqAnyCollection      | 1000      | FortyOnePercent     |      3,379.33 ns |        33.938 ns |        30.085 ns |      1.09 |     0.02 |      17888 B |        1.00 |
-| LinqAllCollection      | 1000      | FortyOnePercent     |      3,242.77 ns |        30.592 ns |        27.119 ns |      1.05 |     0.01 |      17864 B |        1.00 |
-| LinqDistinctCollection | 1000      | FortyOnePercent     |      6,426.06 ns |        90.272 ns |        84.440 ns |      2.08 |     0.04 |      17864 B |        1.00 |
-| LinqGroupByCollection  | 1000      | FortyOnePercent     |     26,477.80 ns |       281.600 ns |       235.149 ns |      8.53 |     0.15 |     104560 B |        5.87 |
-| ToHashSetCollection    | 1000      | FortyOnePercent     |      6,399.74 ns |        65.410 ns |        61.184 ns |      2.07 |     0.04 |      17800 B |        1.00 |
-| ForeachEnumerable      | 1000      | FortyOnePercent     |      5,359.93 ns |        86.938 ns |        81.322 ns |      1.73 |     0.04 |      13064 B |        0.73 |
-| LinqAnyEnumerable      | 1000      | FortyOnePercent     |      5,658.93 ns |        66.418 ns |        62.128 ns |      1.83 |     0.03 |      13152 B |        0.74 |
-| LinqAllEnumerable      | 1000      | FortyOnePercent     |      5,628.23 ns |        87.343 ns |        81.701 ns |      1.82 |     0.04 |      13128 B |        0.74 |
-| LinqDistinctEnumerable | 1000      | FortyOnePercent     |     20,728.75 ns |       196.155 ns |       183.483 ns |      6.70 |     0.10 |      58952 B |        3.31 |
-| LinqGroupByEnumerable  | 1000      | FortyOnePercent     |     30,891.56 ns |       373.838 ns |       349.688 ns |      9.98 |     0.18 |     104640 B |        5.88 |
-| ToHashSetEnumerable    | 1000      | FortyOnePercent     |     20,173.41 ns |       206.796 ns |       183.319 ns |      6.51 |     0.11 |      58888 B |        3.31 |
-|                        |           |                     |                  |                  |                  |           |          |              |             |
-| **ForeachCollection**  | **1000**  | **End**             |  **6,715.74 ns** |    **78.223 ns** |    **73.170 ns** |  **1.00** | **0.00** |  **17800 B** |    **1.00** |
-| LinqAnyCollection      | 1000      | End                 |      7,402.56 ns |        84.102 ns |        78.669 ns |      1.10 |     0.02 |      17888 B |        1.00 |
-| LinqAllCollection      | 1000      | End                 |      7,143.91 ns |        52.693 ns |        49.289 ns |      1.06 |     0.01 |      17864 B |        1.00 |
-| LinqDistinctCollection | 1000      | End                 |      6,399.18 ns |        45.908 ns |        42.942 ns |      0.95 |     0.01 |      17864 B |        1.00 |
-| LinqGroupByCollection  | 1000      | End                 |     31,696.48 ns |       425.905 ns |       398.392 ns |      4.72 |     0.10 |     104560 B |        5.87 |
-| ToHashSetCollection    | 1000      | End                 |      6,416.42 ns |        73.772 ns |        69.006 ns |      0.96 |     0.02 |      17800 B |        1.00 |
-| ForeachEnumerable      | 1000      | End                 |     14,854.95 ns |       225.920 ns |       211.325 ns |      2.21 |     0.05 |      58776 B |        3.30 |
-| LinqAnyEnumerable      | 1000      | End                 |     15,739.06 ns |       255.465 ns |       238.962 ns |      2.34 |     0.03 |      58864 B |        3.31 |
-| LinqAllEnumerable      | 1000      | End                 |     15,392.70 ns |       104.427 ns |        97.681 ns |      2.29 |     0.03 |      58840 B |        3.31 |
-| LinqDistinctEnumerable | 1000      | End                 |     20,894.78 ns |       309.340 ns |       289.357 ns |      3.11 |     0.04 |      58952 B |        3.31 |
-| LinqGroupByEnumerable  | 1000      | End                 |     37,468.86 ns |       358.919 ns |       335.733 ns |      5.58 |     0.10 |     104640 B |        5.88 |
-| ToHashSetEnumerable    | 1000      | End                 |     20,433.63 ns |       202.893 ns |       189.786 ns |      3.04 |     0.04 |      58888 B |        3.31 |
-|                        |           |                     |                  |                  |                  |           |          |              |             |
-| **ForeachCollection**  | **10000** | **None**            | **91,094.10 ns** |   **692.317 ns** |   **647.593 ns** |  **1.00** | **0.00** | **161813 B** |    **1.00** |
-| LinqAnyCollection      | 10000     | None                |    101,183.66 ns |       916.373 ns |       857.176 ns |      1.11 |     0.01 |     161901 B |        1.00 |
-| LinqAllCollection      | 10000     | None                |     97,829.39 ns |       957.686 ns |       895.820 ns |      1.07 |     0.01 |     161877 B |        1.00 |
-| LinqDistinctCollection | 10000     | None                |     91,516.67 ns |       794.299 ns |       742.988 ns |      1.00 |     0.01 |     161877 B |        1.00 |
-| LinqGroupByCollection  | 10000     | None                |    631,615.92 ns |     7,200.612 ns |     6,383.155 ns |      6.93 |     0.09 |    1142454 B |        7.06 |
-| ToHashSetCollection    | 10000     | None                |     93,914.15 ns |     1,270.909 ns |     1,188.809 ns |      1.03 |     0.02 |     161813 B |        1.00 |
-| ForeachEnumerable      | 10000     | None                |    190,685.81 ns |     3,552.224 ns |     3,322.752 ns |      2.09 |     0.04 |     538768 B |        3.33 |
-| LinqAnyEnumerable      | 10000     | None                |    198,816.66 ns |     1,975.771 ns |     1,848.138 ns |      2.18 |     0.03 |     538856 B |        3.33 |
-| LinqAllEnumerable      | 10000     | None                |    197,938.26 ns |     2,650.888 ns |     2,479.642 ns |      2.17 |     0.02 |     538832 B |        3.33 |
-| LinqDistinctEnumerable | 10000     | None                |    250,872.97 ns |     3,581.229 ns |     3,349.884 ns |      2.75 |     0.05 |     538944 B |        3.33 |
-| LinqGroupByEnumerable  | 10000     | None                |    689,133.95 ns |     8,627.327 ns |     8,070.007 ns |      7.57 |     0.09 |    1142534 B |        7.06 |
-| ToHashSetEnumerable    | 10000     | None                |    246,239.22 ns |     3,669.210 ns |     3,432.182 ns |      2.70 |     0.05 |     538880 B |        3.33 |
-|                        |           |                     |                  |                  |                  |           |          |              |             |
-| **ForeachCollection**  | **10000** | **Beginning**       |  **6,880.96 ns** |    **75.955 ns** |    **71.048 ns** | **1.000** | **0.00** | **161813 B** |   **1.000** |
-| LinqAnyCollection      | 10000     | Beginning           |      6,929.99 ns |        64.734 ns |        60.552 ns |     1.007 |     0.01 |     161901 B |       1.001 |
-| LinqAllCollection      | 10000     | Beginning           |      7,097.82 ns |        39.460 ns |        34.981 ns |     1.031 |     0.01 |     161877 B |       1.000 |
-| LinqDistinctCollection | 10000     | Beginning           |     92,580.86 ns |       889.974 ns |       832.482 ns |    13.456 |     0.16 |     161877 B |       1.000 |
-| LinqGroupByCollection  | 10000     | Beginning           |    554,243.57 ns |     7,785.328 ns |     6,901.490 ns |    80.485 |     1.43 |    1142398 B |       7.060 |
-| ToHashSetCollection    | 10000     | Beginning           |     92,985.67 ns |       759.712 ns |       710.635 ns |    13.515 |     0.18 |     161813 B |       1.000 |
-| ForeachEnumerable      | 10000     | Beginning           |         61.03 ns |         0.786 ns |         0.735 ns |     0.009 |     0.00 |        280 B |       0.002 |
-| LinqAnyEnumerable      | 10000     | Beginning           |         71.15 ns |         0.597 ns |         0.530 ns |     0.010 |     0.00 |        368 B |       0.002 |
-| LinqAllEnumerable      | 10000     | Beginning           |         68.66 ns |         0.995 ns |         0.831 ns |     0.010 |     0.00 |        344 B |       0.002 |
-| LinqDistinctEnumerable | 10000     | Beginning           |    244,055.14 ns |     3,413.509 ns |     3,192.998 ns |    35.473 |     0.66 |     538944 B |       3.331 |
-| LinqGroupByEnumerable  | 10000     | Beginning           |    592,099.34 ns |    10,108.234 ns |     9,455.248 ns |    86.058 |     1.65 |    1142478 B |       7.060 |
-| ToHashSetEnumerable    | 10000     | Beginning           |    247,400.21 ns |     4,691.237 ns |     4,388.186 ns |    35.958 |     0.74 |     538880 B |       3.330 |
-|                        |           |                     |                  |                  |                  |           |          |              |             |
-| **ForeachCollection**  | **10000** | **FortyOnePercent** | **44,616.78 ns** |   **406.013 ns** |   **379.784 ns** |  **1.00** | **0.00** | **161813 B** |    **1.00** |
-| LinqAnyCollection      | 10000     | FortyOnePercent     |     48,224.32 ns |       455.001 ns |       425.609 ns |      1.08 |     0.02 |     161901 B |        1.00 |
-| LinqAllCollection      | 10000     | FortyOnePercent     |     46,141.95 ns |       724.256 ns |       677.469 ns |      1.03 |     0.02 |     161877 B |        1.00 |
-| LinqDistinctCollection | 10000     | FortyOnePercent     |     92,884.72 ns |     1,038.201 ns |       971.134 ns |      2.08 |     0.03 |     161877 B |        1.00 |
-| LinqGroupByCollection  | 10000     | FortyOnePercent     |    584,942.94 ns |     8,072.656 ns |     7,156.199 ns |     13.12 |     0.22 |    1142398 B |        7.06 |
-| ToHashSetCollection    | 10000     | FortyOnePercent     |     95,377.13 ns |       964.132 ns |       901.850 ns |      2.14 |     0.02 |     161813 B |        1.00 |
-| ForeachEnumerable      | 10000     | FortyOnePercent     |     78,826.93 ns |       868.845 ns |       770.209 ns |      1.77 |     0.03 |     258387 B |        1.60 |
-| LinqAnyEnumerable      | 10000     | FortyOnePercent     |     82,660.12 ns |     1,466.371 ns |     1,371.644 ns |      1.85 |     0.04 |     258475 B |        1.60 |
-| LinqAllEnumerable      | 10000     | FortyOnePercent     |     83,556.19 ns |       754.950 ns |       706.181 ns |      1.87 |     0.02 |     258451 B |        1.60 |
-| LinqDistinctEnumerable | 10000     | FortyOnePercent     |    250,828.61 ns |     2,097.124 ns |     1,961.651 ns |      5.62 |     0.06 |     538944 B |        3.33 |
-| LinqGroupByEnumerable  | 10000     | FortyOnePercent     |    634,920.74 ns |     8,810.078 ns |     8,240.952 ns |     14.23 |     0.19 |    1142478 B |        7.06 |
-| ToHashSetEnumerable    | 10000     | FortyOnePercent     |    245,208.85 ns |     3,574.293 ns |     3,343.396 ns |      5.50 |     0.09 |     538880 B |        3.33 |
-|                        |           |                     |                  |                  |                  |           |          |              |             |
-| **ForeachCollection**  | **10000** | **End**             | **93,863.65 ns** | **1,186.485 ns** | **1,109.839 ns** |  **1.00** | **0.00** | **161813 B** |    **1.00** |
-| LinqAnyCollection      | 10000     | End                 |    102,418.73 ns |     1,008.851 ns |       943.679 ns |      1.09 |     0.02 |     161901 B |        1.00 |
-| LinqAllCollection      | 10000     | End                 |     98,568.97 ns |     1,024.512 ns |       958.329 ns |      1.05 |     0.02 |     161877 B |        1.00 |
-| LinqDistinctCollection | 10000     | End                 |     92,095.89 ns |     1,032.460 ns |       965.764 ns |      0.98 |     0.02 |     161877 B |        1.00 |
-| LinqGroupByCollection  | 10000     | End                 |    660,996.44 ns |    12,410.031 ns |    11,608.351 ns |      7.04 |     0.16 |    1142398 B |        7.06 |
-| ToHashSetCollection    | 10000     | End                 |     92,595.27 ns |       595.160 ns |       527.594 ns |      0.99 |     0.01 |     161813 B |        1.00 |
-| ForeachEnumerable      | 10000     | End                 |    189,140.06 ns |     2,291.882 ns |     2,143.828 ns |      2.02 |     0.03 |     538768 B |        3.33 |
-| LinqAnyEnumerable      | 10000     | End                 |    201,139.02 ns |     2,536.438 ns |     2,372.586 ns |      2.14 |     0.04 |     538856 B |        3.33 |
-| LinqAllEnumerable      | 10000     | End                 |    200,562.64 ns |     3,482.309 ns |     3,257.354 ns |      2.14 |     0.04 |     538832 B |        3.33 |
-| LinqDistinctEnumerable | 10000     | End                 |    254,411.98 ns |     2,737.680 ns |     2,426.882 ns |      2.71 |     0.03 |     538944 B |        3.33 |
-| LinqGroupByEnumerable  | 10000     | End                 |    732,982.67 ns |     6,508.309 ns |     5,081.259 ns |      7.82 |     0.13 |    1142478 B |        7.06 |
-| ToHashSetEnumerable    | 10000     | End                 |    247,684.04 ns |     4,326.799 ns |     5,922.572 ns |      2.63 |     0.07 |     538880 B |        3.33 |
+BenchmarkDotNet=v0.13.2, OS=Windows 11 (10.0.22621.2283)
+12th Gen Intel Core i7-12700H, 1 CPU, 20 logical and 14 physical cores
+.NET SDK=8.0.100-preview.7.23376.3
+  [Host]     : .NET 8.0.0 (8.0.23.37506), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.37506), X64 RyuJIT AVX2
+
+
+```
+|       Method |  Size | DuplicateLocation | CollectionType |          Mean |         Error |        StdDev |        Median |     Ratio | RatioSD | Allocated | Alloc Ratio |
+|------------- |------ |------------------ |--------------- |--------------:|--------------:|--------------:|--------------:|----------:|--------:|----------:|------------:|
+|      **Foreach** |   **100** |              **None** |          **Array** |     **509.29 ns** |      **7.411 ns** |      **6.188 ns** |     **509.99 ns** |      **1.00** |    **0.00** |    **1864 B** |        **1.00** |
+|      LinqAny |   100 |              None |          Array |     630.51 ns |      8.572 ns |      7.599 ns |     629.13 ns |      1.24 |    0.03 |    1952 B |        1.05 |
+|      LinqAll |   100 |              None |          Array |     560.42 ns |      4.827 ns |      4.031 ns |     560.47 ns |      1.10 |    0.02 |    1928 B |        1.03 |
+| LinqDistinct |   100 |              None |          Array |     525.37 ns |     10.210 ns |     10.485 ns |     528.53 ns |      1.03 |    0.03 |    1928 B |        1.03 |
+|  LinqGroupBy |   100 |              None |          Array |   2,544.85 ns |     47.961 ns |     53.308 ns |   2,559.89 ns |      4.96 |    0.13 |   11032 B |        5.92 |
+|    ToHashSet |   100 |              None |          Array |     536.66 ns |      6.946 ns |      6.497 ns |     537.17 ns |      1.05 |    0.02 |    1864 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |   **100** |              **None** |     **Enumerable** |   **1,195.92 ns** |     **23.780 ns** |     **46.382 ns** |   **1,176.30 ns** |      **1.00** |    **0.00** |    **6112 B** |        **1.00** |
+|      LinqAny |   100 |              None |     Enumerable |   1,237.36 ns |     13.536 ns |     11.999 ns |   1,238.64 ns |      0.98 |    0.02 |    6200 B |        1.01 |
+|      LinqAll |   100 |              None |     Enumerable |   1,163.70 ns |     16.393 ns |     15.334 ns |   1,161.57 ns |      0.93 |    0.02 |    6176 B |        1.01 |
+| LinqDistinct |   100 |              None |     Enumerable |   1,531.50 ns |     18.042 ns |     15.994 ns |   1,531.16 ns |      1.21 |    0.02 |    6288 B |        1.03 |
+|  LinqGroupBy |   100 |              None |     Enumerable |   2,707.20 ns |     29.221 ns |     27.333 ns |   2,702.41 ns |      2.15 |    0.06 |   11112 B |        1.82 |
+|    ToHashSet |   100 |              None |     Enumerable |   1,497.04 ns |     14.213 ns |     13.295 ns |   1,494.99 ns |      1.19 |    0.03 |    6224 B |        1.02 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |   **100** |         **Beginning** |          **Array** |      **76.41 ns** |      **1.600 ns** |      **1.497 ns** |      **76.96 ns** |      **1.00** |    **0.00** |    **1864 B** |        **1.00** |
+|      LinqAny |   100 |         Beginning |          Array |      83.10 ns |      1.405 ns |      1.314 ns |      82.66 ns |      1.09 |    0.03 |    1952 B |        1.05 |
+|      LinqAll |   100 |         Beginning |          Array |      78.97 ns |      1.577 ns |      1.619 ns |      79.02 ns |      1.04 |    0.02 |    1928 B |        1.03 |
+| LinqDistinct |   100 |         Beginning |          Array |     499.30 ns |      9.493 ns |      8.880 ns |     498.92 ns |      6.54 |    0.17 |    1928 B |        1.03 |
+|  LinqGroupBy |   100 |         Beginning |          Array |   1,838.40 ns |     31.122 ns |     47.527 ns |   1,821.41 ns |     24.43 |    0.78 |   10976 B |        5.89 |
+|    ToHashSet |   100 |         Beginning |          Array |     495.64 ns |      4.430 ns |      3.927 ns |     495.16 ns |      6.49 |    0.11 |    1864 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |   **100** |         **Beginning** |     **Enumerable** |      **41.34 ns** |      **0.677 ns** |      **0.633 ns** |      **41.21 ns** |      **1.00** |    **0.00** |     **280 B** |        **1.00** |
+|      LinqAny |   100 |         Beginning |     Enumerable |      49.12 ns |      0.482 ns |      0.451 ns |      49.30 ns |      1.19 |    0.02 |     368 B |        1.31 |
+|      LinqAll |   100 |         Beginning |     Enumerable |      45.40 ns |      0.398 ns |      0.352 ns |      45.33 ns |      1.10 |    0.02 |     344 B |        1.23 |
+| LinqDistinct |   100 |         Beginning |     Enumerable |   1,576.97 ns |     31.569 ns |     31.005 ns |   1,578.58 ns |     38.13 |    0.75 |    6288 B |       22.46 |
+|  LinqGroupBy |   100 |         Beginning |     Enumerable |   2,049.56 ns |     39.167 ns |     41.908 ns |   2,053.40 ns |     49.51 |    1.44 |   11056 B |       39.49 |
+|    ToHashSet |   100 |         Beginning |     Enumerable |   1,532.25 ns |     14.659 ns |     12.241 ns |   1,532.09 ns |     37.08 |    0.46 |    6224 B |       22.23 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |   **100** |   **FortyOnePercent** |          **Array** |     **276.12 ns** |      **5.458 ns** |      **7.287 ns** |     **275.99 ns** |      **1.00** |    **0.00** |    **1864 B** |        **1.00** |
+|      LinqAny |   100 |   FortyOnePercent |          Array |     305.24 ns |      5.211 ns |      4.875 ns |     303.35 ns |      1.11 |    0.05 |    1952 B |        1.05 |
+|      LinqAll |   100 |   FortyOnePercent |          Array |     281.73 ns |      5.446 ns |      5.827 ns |     282.57 ns |      1.02 |    0.03 |    1928 B |        1.03 |
+| LinqDistinct |   100 |   FortyOnePercent |          Array |     518.60 ns |      9.814 ns |     10.078 ns |     516.67 ns |      1.87 |    0.06 |    1928 B |        1.03 |
+|  LinqGroupBy |   100 |   FortyOnePercent |          Array |   2,157.15 ns |     22.612 ns |     21.152 ns |   2,157.48 ns |      7.81 |    0.25 |   10976 B |        5.89 |
+|    ToHashSet |   100 |   FortyOnePercent |          Array |     529.03 ns |      6.473 ns |      5.738 ns |     529.83 ns |      1.92 |    0.06 |    1864 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |   **100** |   **FortyOnePercent** |     **Enumerable** |     **592.29 ns** |      **7.031 ns** |      **6.577 ns** |     **592.38 ns** |      **1.00** |    **0.00** |    **2904 B** |        **1.00** |
+|      LinqAny |   100 |   FortyOnePercent |     Enumerable |     606.11 ns |     12.119 ns |     15.327 ns |     603.99 ns |      1.02 |    0.03 |    2992 B |        1.03 |
+|      LinqAll |   100 |   FortyOnePercent |     Enumerable |     578.34 ns |      6.970 ns |      6.520 ns |     576.95 ns |      0.98 |    0.01 |    2968 B |        1.02 |
+| LinqDistinct |   100 |   FortyOnePercent |     Enumerable |   1,612.72 ns |     22.169 ns |     20.737 ns |   1,620.28 ns |      2.72 |    0.06 |    6288 B |        2.17 |
+|  LinqGroupBy |   100 |   FortyOnePercent |     Enumerable |   2,385.22 ns |     29.971 ns |     26.568 ns |   2,382.86 ns |      4.03 |    0.05 |   11056 B |        3.81 |
+|    ToHashSet |   100 |   FortyOnePercent |     Enumerable |   1,549.72 ns |     22.578 ns |     21.120 ns |   1,546.13 ns |      2.62 |    0.04 |    6224 B |        2.14 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |   **100** |               **End** |          **Array** |     **498.11 ns** |      **5.510 ns** |      **5.154 ns** |     **498.17 ns** |      **1.00** |    **0.00** |    **1864 B** |        **1.00** |
+|      LinqAny |   100 |               End |          Array |     612.99 ns |      6.269 ns |      5.557 ns |     614.90 ns |      1.23 |    0.02 |    1952 B |        1.05 |
+|      LinqAll |   100 |               End |          Array |     535.88 ns |      9.518 ns |      8.903 ns |     534.57 ns |      1.08 |    0.02 |    1928 B |        1.03 |
+| LinqDistinct |   100 |               End |          Array |     514.97 ns |      9.633 ns |      9.461 ns |     512.04 ns |      1.03 |    0.02 |    1928 B |        1.03 |
+|  LinqGroupBy |   100 |               End |          Array |   2,474.43 ns |     41.298 ns |     36.610 ns |   2,481.73 ns |      4.96 |    0.08 |   10976 B |        5.89 |
+|    ToHashSet |   100 |               End |          Array |     513.28 ns |      9.078 ns |     10.455 ns |     510.85 ns |      1.03 |    0.02 |    1864 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |   **100** |               **End** |     **Enumerable** |   **1,282.55 ns** |     **25.276 ns** |     **27.045 ns** |   **1,276.39 ns** |      **1.00** |    **0.00** |    **6112 B** |        **1.00** |
+|      LinqAny |   100 |               End |     Enumerable |   1,332.67 ns |     17.776 ns |     16.628 ns |   1,334.75 ns |      1.04 |    0.02 |    6200 B |        1.01 |
+|      LinqAll |   100 |               End |     Enumerable |   1,228.58 ns |     24.457 ns |     28.164 ns |   1,222.28 ns |      0.96 |    0.03 |    6176 B |        1.01 |
+| LinqDistinct |   100 |               End |     Enumerable |   1,588.08 ns |     30.178 ns |     28.229 ns |   1,588.76 ns |      1.23 |    0.02 |    6288 B |        1.03 |
+|  LinqGroupBy |   100 |               End |     Enumerable |   2,787.90 ns |     47.981 ns |     44.881 ns |   2,779.52 ns |      2.17 |    0.05 |   11056 B |        1.81 |
+|    ToHashSet |   100 |               End |     Enumerable |   1,581.83 ns |     16.809 ns |     15.723 ns |   1,582.29 ns |      1.23 |    0.03 |    6224 B |        1.02 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |  **1000** |              **None** |          **Array** |   **4,695.82 ns** |     **71.926 ns** |     **63.761 ns** |   **4,713.15 ns** |      **1.00** |    **0.00** |   **17800 B** |        **1.00** |
+|      LinqAny |  1000 |              None |          Array |   5,900.21 ns |     44.162 ns |     41.309 ns |   5,897.83 ns |      1.26 |    0.02 |   17888 B |        1.00 |
+|      LinqAll |  1000 |              None |          Array |   5,070.21 ns |     63.098 ns |     55.935 ns |   5,086.93 ns |      1.08 |    0.01 |   17864 B |        1.00 |
+| LinqDistinct |  1000 |              None |          Array |   4,734.70 ns |     77.549 ns |     72.540 ns |   4,723.59 ns |      1.01 |    0.02 |   17864 B |        1.00 |
+|  LinqGroupBy |  1000 |              None |          Array |  23,379.78 ns |    247.116 ns |    219.062 ns |  23,452.48 ns |      4.98 |    0.08 |  104616 B |        5.88 |
+|    ToHashSet |  1000 |              None |          Array |   4,668.11 ns |     90.684 ns |    111.368 ns |   4,681.69 ns |      0.99 |    0.02 |   17800 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |  **1000** |              **None** |     **Enumerable** |  **10,369.32 ns** |    **123.794 ns** |    **115.797 ns** |  **10,372.60 ns** |      **1.00** |    **0.00** |   **58776 B** |        **1.00** |
+|      LinqAny |  1000 |              None |     Enumerable |  11,117.63 ns |    143.456 ns |    134.189 ns |  11,168.39 ns |      1.07 |    0.01 |   58864 B |        1.00 |
+|      LinqAll |  1000 |              None |     Enumerable |  10,363.67 ns |    157.114 ns |    146.965 ns |  10,348.99 ns |      1.00 |    0.02 |   58840 B |        1.00 |
+| LinqDistinct |  1000 |              None |     Enumerable |  13,552.33 ns |    199.926 ns |    166.947 ns |  13,580.69 ns |      1.31 |    0.02 |   58952 B |        1.00 |
+|  LinqGroupBy |  1000 |              None |     Enumerable |  24,873.57 ns |    395.700 ns |    370.138 ns |  24,767.11 ns |      2.40 |    0.04 |  104696 B |        1.78 |
+|    ToHashSet |  1000 |              None |     Enumerable |  13,171.53 ns |    135.057 ns |    126.332 ns |  13,141.87 ns |      1.27 |    0.02 |   58888 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |  **1000** |         **Beginning** |          **Array** |     **521.27 ns** |      **6.899 ns** |      **6.453 ns** |     **521.15 ns** |      **1.00** |    **0.00** |   **17800 B** |        **1.00** |
+|      LinqAny |  1000 |         Beginning |          Array |     530.60 ns |      8.946 ns |      8.368 ns |     531.77 ns |      1.02 |    0.01 |   17888 B |        1.00 |
+|      LinqAll |  1000 |         Beginning |          Array |     530.03 ns |     10.094 ns |      9.442 ns |     529.91 ns |      1.02 |    0.02 |   17864 B |        1.00 |
+| LinqDistinct |  1000 |         Beginning |          Array |   4,638.04 ns |     20.007 ns |     16.707 ns |   4,646.49 ns |      8.90 |    0.12 |   17864 B |        1.00 |
+|  LinqGroupBy |  1000 |         Beginning |          Array |  17,444.32 ns |    174.822 ns |    163.528 ns |  17,407.64 ns |     33.47 |    0.43 |  104560 B |        5.87 |
+|    ToHashSet |  1000 |         Beginning |          Array |   4,632.13 ns |     38.545 ns |     32.187 ns |   4,639.58 ns |      8.89 |    0.12 |   17800 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |  **1000** |         **Beginning** |     **Enumerable** |      **41.51 ns** |      **0.762 ns** |      **0.712 ns** |      **41.73 ns** |      **1.00** |    **0.00** |     **280 B** |        **1.00** |
+|      LinqAny |  1000 |         Beginning |     Enumerable |      47.99 ns |      0.945 ns |      0.928 ns |      48.00 ns |      1.16 |    0.03 |     368 B |        1.31 |
+|      LinqAll |  1000 |         Beginning |     Enumerable |      46.41 ns |      0.446 ns |      0.395 ns |      46.44 ns |      1.12 |    0.03 |     344 B |        1.23 |
+| LinqDistinct |  1000 |         Beginning |     Enumerable |  13,578.13 ns |    106.116 ns |     99.261 ns |  13,565.01 ns |    327.17 |    4.39 |   58952 B |      210.54 |
+|  LinqGroupBy |  1000 |         Beginning |     Enumerable |  19,639.96 ns |    223.485 ns |    209.048 ns |  19,635.02 ns |    473.31 |   11.39 |  104640 B |      373.71 |
+|    ToHashSet |  1000 |         Beginning |     Enumerable |  14,183.79 ns |    212.563 ns |    188.432 ns |  14,244.92 ns |    341.93 |    5.84 |   58888 B |      210.31 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |  **1000** |   **FortyOnePercent** |          **Array** |   **2,639.49 ns** |     **52.208 ns** |    **106.648 ns** |   **2,644.74 ns** |      **1.00** |    **0.00** |   **17800 B** |        **1.00** |
+|      LinqAny |  1000 |   FortyOnePercent |          Array |   2,871.67 ns |     37.329 ns |     33.091 ns |   2,871.95 ns |      1.11 |    0.07 |   17888 B |        1.00 |
+|      LinqAll |  1000 |   FortyOnePercent |          Array |   2,509.79 ns |     41.744 ns |     39.047 ns |   2,498.08 ns |      0.97 |    0.06 |   17864 B |        1.00 |
+| LinqDistinct |  1000 |   FortyOnePercent |          Array |   5,078.23 ns |    110.681 ns |    322.860 ns |   4,944.50 ns |      2.01 |    0.14 |   17864 B |        1.00 |
+|  LinqGroupBy |  1000 |   FortyOnePercent |          Array |  20,094.32 ns |    206.098 ns |    192.784 ns |  20,043.43 ns |      7.76 |    0.38 |  104560 B |        5.87 |
+|    ToHashSet |  1000 |   FortyOnePercent |          Array |   4,760.18 ns |     54.574 ns |     51.049 ns |   4,749.52 ns |      1.84 |    0.11 |   17800 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |  **1000** |   **FortyOnePercent** |     **Enumerable** |   **3,739.15 ns** |     **38.894 ns** |     **36.381 ns** |   **3,742.16 ns** |      **1.00** |    **0.00** |   **13064 B** |        **1.00** |
+|      LinqAny |  1000 |   FortyOnePercent |     Enumerable |   4,058.53 ns |     41.469 ns |     38.790 ns |   4,045.93 ns |      1.09 |    0.02 |   13152 B |        1.01 |
+|      LinqAll |  1000 |   FortyOnePercent |     Enumerable |   3,768.74 ns |     32.094 ns |     30.021 ns |   3,765.82 ns |      1.01 |    0.01 |   13128 B |        1.00 |
+| LinqDistinct |  1000 |   FortyOnePercent |     Enumerable |  13,799.60 ns |    133.805 ns |    125.161 ns |  13,800.78 ns |      3.69 |    0.06 |   58952 B |        4.51 |
+|  LinqGroupBy |  1000 |   FortyOnePercent |     Enumerable |  21,069.78 ns |    184.656 ns |    172.728 ns |  21,103.02 ns |      5.64 |    0.08 |  104640 B |        8.01 |
+|    ToHashSet |  1000 |   FortyOnePercent |     Enumerable |  13,530.68 ns |     72.890 ns |     68.181 ns |  13,523.89 ns |      3.62 |    0.03 |   58888 B |        4.51 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |  **1000** |               **End** |          **Array** |   **4,671.53 ns** |     **57.754 ns** |     **51.197 ns** |   **4,673.27 ns** |      **1.00** |    **0.00** |   **17800 B** |        **1.00** |
+|      LinqAny |  1000 |               End |          Array |   5,996.29 ns |     76.885 ns |     71.919 ns |   6,003.00 ns |      1.28 |    0.02 |   17888 B |        1.00 |
+|      LinqAll |  1000 |               End |          Array |   5,104.82 ns |     75.458 ns |     70.584 ns |   5,095.29 ns |      1.09 |    0.02 |   17864 B |        1.00 |
+| LinqDistinct |  1000 |               End |          Array |   4,685.45 ns |     89.351 ns |     95.605 ns |   4,674.33 ns |      1.00 |    0.02 |   17864 B |        1.00 |
+|  LinqGroupBy |  1000 |               End |          Array |  23,665.84 ns |    329.299 ns |    308.027 ns |  23,651.97 ns |      5.07 |    0.08 |  104560 B |        5.87 |
+|    ToHashSet |  1000 |               End |          Array |   4,738.79 ns |     51.363 ns |     48.045 ns |   4,736.95 ns |      1.01 |    0.02 |   17800 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** |  **1000** |               **End** |     **Enumerable** |  **10,395.77 ns** |    **120.868 ns** |    **113.060 ns** |  **10,385.32 ns** |      **1.00** |    **0.00** |   **58776 B** |        **1.00** |
+|      LinqAny |  1000 |               End |     Enumerable |  11,207.78 ns |    147.704 ns |    130.936 ns |  11,205.08 ns |      1.08 |    0.01 |   58864 B |        1.00 |
+|      LinqAll |  1000 |               End |     Enumerable |  10,450.92 ns |    168.406 ns |    157.527 ns |  10,453.84 ns |      1.01 |    0.02 |   58840 B |        1.00 |
+| LinqDistinct |  1000 |               End |     Enumerable |  13,662.70 ns |    151.984 ns |    142.166 ns |  13,634.60 ns |      1.31 |    0.02 |   58952 B |        1.00 |
+|  LinqGroupBy |  1000 |               End |     Enumerable |  24,826.40 ns |    129.864 ns |    115.121 ns |  24,819.26 ns |      2.39 |    0.03 |  104640 B |        1.78 |
+|    ToHashSet |  1000 |               End |     Enumerable |  13,672.79 ns |     87.873 ns |     82.196 ns |  13,679.70 ns |      1.32 |    0.01 |   58888 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** | **10000** |              **None** |          **Array** |  **69,390.25 ns** |    **656.529 ns** |    **614.118 ns** |  **69,438.68 ns** |      **1.00** |    **0.00** |  **161813 B** |        **1.00** |
+|      LinqAny | 10000 |              None |          Array |  80,424.97 ns |    851.736 ns |    711.238 ns |  80,545.40 ns |      1.16 |    0.01 |  161901 B |        1.00 |
+|      LinqAll | 10000 |              None |          Array |  73,589.33 ns |  1,130.815 ns |  1,057.765 ns |  73,731.71 ns |      1.06 |    0.02 |  161877 B |        1.00 |
+| LinqDistinct | 10000 |              None |          Array |  71,028.81 ns |    829.147 ns |    775.584 ns |  71,029.02 ns |      1.02 |    0.01 |  161877 B |        1.00 |
+|  LinqGroupBy | 10000 |              None |          Array | 565,841.67 ns | 11,291.415 ns | 22,550.175 ns | 557,524.61 ns |      8.29 |    0.41 | 1142454 B |        7.06 |
+|    ToHashSet | 10000 |              None |          Array |  72,665.45 ns |    757.276 ns |    708.357 ns |  72,711.22 ns |      1.05 |    0.01 |  161813 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** | **10000** |              **None** |     **Enumerable** | **145,382.52 ns** |  **1,077.163 ns** |  **1,007.579 ns** | **145,194.97 ns** |      **1.00** |    **0.00** |  **538768 B** |        **1.00** |
+|      LinqAny | 10000 |              None |     Enumerable | 152,204.07 ns |  1,865.139 ns |  1,744.652 ns | 152,304.44 ns |      1.05 |    0.01 |  538856 B |        1.00 |
+|      LinqAll | 10000 |              None |     Enumerable | 146,130.62 ns |  1,444.017 ns |  1,280.084 ns | 146,274.48 ns |      1.00 |    0.01 |  538832 B |        1.00 |
+| LinqDistinct | 10000 |              None |     Enumerable | 177,543.27 ns |  2,483.727 ns |  2,323.280 ns | 177,703.15 ns |      1.22 |    0.02 |  538944 B |        1.00 |
+|  LinqGroupBy | 10000 |              None |     Enumerable | 578,089.15 ns | 10,332.773 ns | 10,148.164 ns | 574,785.84 ns |      3.98 |    0.08 | 1142534 B |        2.12 |
+|    ToHashSet | 10000 |              None |     Enumerable | 176,401.25 ns |  1,596.310 ns |  1,493.189 ns | 176,638.67 ns |      1.21 |    0.01 |  538880 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** | **10000** |         **Beginning** |          **Array** |   **5,911.94 ns** |     **67.344 ns** |     **62.993 ns** |   **5,911.37 ns** |      **1.00** |    **0.00** |  **161813 B** |        **1.00** |
+|      LinqAny | 10000 |         Beginning |          Array |   5,944.57 ns |     70.752 ns |     66.182 ns |   5,957.92 ns |      1.01 |    0.01 |  161901 B |        1.00 |
+|      LinqAll | 10000 |         Beginning |          Array |   5,961.54 ns |     81.933 ns |     76.640 ns |   5,978.02 ns |      1.01 |    0.01 |  161877 B |        1.00 |
+| LinqDistinct | 10000 |         Beginning |          Array |  70,611.90 ns |  1,139.780 ns |  1,066.151 ns |  70,673.90 ns |     11.95 |    0.22 |  161877 B |        1.00 |
+|  LinqGroupBy | 10000 |         Beginning |          Array | 536,250.27 ns | 10,577.696 ns | 19,867.477 ns | 539,511.47 ns |     91.32 |    3.41 | 1142398 B |        7.06 |
+|    ToHashSet | 10000 |         Beginning |          Array |  71,104.55 ns |    462.128 ns |    432.274 ns |  71,082.69 ns |     12.03 |    0.16 |  161813 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** | **10000** |         **Beginning** |     **Enumerable** |      **41.70 ns** |      **0.336 ns** |      **0.315 ns** |      **41.73 ns** |      **1.00** |    **0.00** |     **280 B** |        **1.00** |
+|      LinqAny | 10000 |         Beginning |     Enumerable |      48.77 ns |      0.364 ns |      0.323 ns |      48.76 ns |      1.17 |    0.01 |     368 B |        1.31 |
+|      LinqAll | 10000 |         Beginning |     Enumerable |      46.39 ns |      0.422 ns |      0.374 ns |      46.32 ns |      1.11 |    0.01 |     344 B |        1.23 |
+| LinqDistinct | 10000 |         Beginning |     Enumerable | 173,348.45 ns |  1,639.076 ns |  1,533.193 ns | 173,348.83 ns |  4,156.89 |   43.39 |  538944 B |    1,924.80 |
+|  LinqGroupBy | 10000 |         Beginning |     Enumerable | 516,625.19 ns |  9,973.466 ns |  9,795.277 ns | 515,386.87 ns | 12,391.24 |  291.35 | 1142478 B |    4,080.28 |
+|    ToHashSet | 10000 |         Beginning |     Enumerable | 179,468.29 ns |  3,498.011 ns |  3,888.030 ns | 179,204.98 ns |  4,322.45 |  114.36 |  538880 B |    1,924.57 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** | **10000** |   **FortyOnePercent** |          **Array** |  **33,703.80 ns** |    **460.392 ns** |    **430.651 ns** |  **33,657.34 ns** |      **1.00** |    **0.00** |  **161813 B** |        **1.00** |
+|      LinqAny | 10000 |   FortyOnePercent |          Array |  37,602.12 ns |    468.775 ns |    415.557 ns |  37,451.57 ns |      1.11 |    0.02 |  161901 B |        1.00 |
+|      LinqAll | 10000 |   FortyOnePercent |          Array |  35,521.96 ns |    305.069 ns |    254.746 ns |  35,584.62 ns |      1.05 |    0.01 |  161877 B |        1.00 |
+| LinqDistinct | 10000 |   FortyOnePercent |          Array |  71,606.63 ns |  1,150.281 ns |  1,075.973 ns |  71,640.28 ns |      2.13 |    0.05 |  161877 B |        1.00 |
+|  LinqGroupBy | 10000 |   FortyOnePercent |          Array | 548,037.20 ns | 10,954.127 ns | 21,876.575 ns | 548,118.65 ns |     16.32 |    0.77 | 1142398 B |        7.06 |
+|    ToHashSet | 10000 |   FortyOnePercent |          Array |  71,015.45 ns |  1,150.894 ns |  1,076.547 ns |  71,230.09 ns |      2.11 |    0.04 |  161813 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** | **10000** |   **FortyOnePercent** |     **Enumerable** |  **59,400.63 ns** |    **790.747 ns** |    **700.976 ns** |  **59,405.87 ns** |      **1.00** |    **0.00** |  **258386 B** |        **1.00** |
+|      LinqAny | 10000 |   FortyOnePercent |     Enumerable |  63,467.14 ns |  1,199.230 ns |  1,121.761 ns |  63,164.76 ns |      1.07 |    0.02 |  258474 B |        1.00 |
+|      LinqAll | 10000 |   FortyOnePercent |     Enumerable |  59,756.61 ns |    793.628 ns |    742.360 ns |  59,802.70 ns |      1.01 |    0.02 |  258450 B |        1.00 |
+| LinqDistinct | 10000 |   FortyOnePercent |     Enumerable | 175,129.57 ns |  2,220.572 ns |  2,077.124 ns | 174,798.17 ns |      2.95 |    0.05 |  538944 B |        2.09 |
+|  LinqGroupBy | 10000 |   FortyOnePercent |     Enumerable | 540,895.51 ns | 10,404.570 ns | 13,158.450 ns | 540,236.72 ns |      9.12 |    0.28 | 1142478 B |        4.42 |
+|    ToHashSet | 10000 |   FortyOnePercent |     Enumerable | 178,194.95 ns |  3,440.222 ns |  3,049.667 ns | 177,109.66 ns |      3.00 |    0.06 |  538880 B |        2.09 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** | **10000** |               **End** |          **Array** |  **70,900.92 ns** |    **639.482 ns** |    **566.884 ns** |  **71,098.77 ns** |      **1.00** |    **0.00** |  **161813 B** |        **1.00** |
+|      LinqAny | 10000 |               End |          Array |  80,729.85 ns |    759.182 ns |    710.139 ns |  80,874.63 ns |      1.14 |    0.01 |  161901 B |        1.00 |
+|      LinqAll | 10000 |               End |          Array |  73,956.99 ns |  1,395.174 ns |  1,305.047 ns |  74,063.27 ns |      1.04 |    0.02 |  161877 B |        1.00 |
+| LinqDistinct | 10000 |               End |          Array |  71,398.06 ns |  1,286.936 ns |  1,203.801 ns |  71,178.30 ns |      1.01 |    0.02 |  161877 B |        1.00 |
+|  LinqGroupBy | 10000 |               End |          Array | 588,249.86 ns | 11,717.346 ns | 17,537.972 ns | 587,790.14 ns |      8.24 |    0.26 | 1142398 B |        7.06 |
+|    ToHashSet | 10000 |               End |          Array |  70,745.33 ns |    716.313 ns |    670.039 ns |  70,782.15 ns |      1.00 |    0.01 |  161813 B |        1.00 |
+|              |       |                   |                |               |               |               |               |           |         |           |             |
+|      **Foreach** | **10000** |               **End** |     **Enumerable** | **144,571.47 ns** |  **2,324.323 ns** |  **2,174.173 ns** | **144,759.16 ns** |      **1.00** |    **0.00** |  **538768 B** |        **1.00** |
+|      LinqAny | 10000 |               End |     Enumerable | 150,326.75 ns |  2,437.770 ns |  2,280.292 ns | 150,122.05 ns |      1.04 |    0.02 |  538856 B |        1.00 |
+|      LinqAll | 10000 |               End |     Enumerable | 144,987.69 ns |  1,858.720 ns |  1,738.648 ns | 145,466.09 ns |      1.00 |    0.02 |  538832 B |        1.00 |
+| LinqDistinct | 10000 |               End |     Enumerable | 177,692.33 ns |  3,300.151 ns |  3,086.964 ns | 178,458.30 ns |      1.23 |    0.03 |  538944 B |        1.00 |
+|  LinqGroupBy | 10000 |               End |     Enumerable | 583,122.53 ns | 10,231.521 ns | 19,217.276 ns | 580,200.44 ns |      4.04 |    0.16 | 1142478 B |        2.12 |
+|    ToHashSet | 10000 |               End |     Enumerable | 174,950.47 ns |  2,303.043 ns |  2,154.268 ns | 175,203.49 ns |      1.21 |    0.02 |  538880 B |        1.00 |
 
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -199,3 +199,4 @@ https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rule
 
 - [@darren-clark](https://github.com/darren-clark)
 - [@GeorgeTsiokos](https://github.com/GeorgeTsiokos)
+- [@rchoffardet](https://github.com/rchoffardet)


### PR DESCRIPTION
- Update the dotnet version to latest (still in RC though)
- Parametrize the collection type (Array/Enumerable) to reduce the amount of code
- Rerun the benchmark 