### PR TITLE
Add TwoPointers method

### DIFF
--- a/FindDuplicates/Benchmark.cs
+++ b/FindDuplicates/Benchmark.cs
@@ -59,6 +59,12 @@ public class Benchmark
         return ContainsDuplicates.ToHashSet(_collection);
     }
 
+    [Benchmark]
+    public bool TwoPointers()
+    {
+        return ContainsDuplicates.TwoPointers(_collection);
+    }
+
     private int? GetDuplicateIndex() => DuplicateLocation switch
     {
         Location.None => default,

--- a/FindDuplicates/ContainsDuplicates.cs
+++ b/FindDuplicates/ContainsDuplicates.cs
@@ -60,4 +60,22 @@ public static class ContainsDuplicates
 
         return enumerable.ToHashSet().Count != count;
     }
+
+    public static bool TwoPointers<T>(IEnumerable<T> enumerable)
+    {
+        var list = enumerable.ToList();
+        var left = 0;
+        var right = left + 1;
+
+        while (right < list.Count)
+        {
+            if (EqualityComparer<T>.Default.Equals(list[left], list[right]))
+                return true;
+
+            left++;
+            right++;
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
The benchmark showed good results. Also, if we work with a large collection and we need to save memory, we can use the ToArray() method instead of ToList(). Array may require less memory since it does not have the added dynamic size control of List.